### PR TITLE
Feature/make parsing pre existing crontab optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ And then you can delete a job you don't want anymore:
 
 When you create a Crontab, it will automatically parse your current crontab file and add all present job into your new object.
 
+Explicitely set the constructor argument `$parseExistingCrontab` to false if you do not want to parse the current crontab file. 
+
 Resources
 ---------
 

--- a/src/Crontab/Crontab.php
+++ b/src/Crontab/Crontab.php
@@ -32,10 +32,14 @@ class Crontab
 
     /**
      * Constructor
+     *
+     * @param bool|true $parseExistingCrontab
      */
-    public function __construct()
+    public function __construct($parseExistingCrontab = true)
     {
-        $this->getCrontabFileHandler()->parseExistingCrontab($this);
+        if ($parseExistingCrontab) {
+            $this->getCrontabFileHandler()->parseExistingCrontab($this);
+        }
     }
 
     /**

--- a/tests/Crontab/Tests/CrontabTest.php
+++ b/tests/Crontab/Tests/CrontabTest.php
@@ -69,4 +69,35 @@ class CrontabTest extends \PHPUnit_Framework_TestCase
             $this->crontab->render()
         );
     }
+
+    public function testParseExistingCrontabByDefault()
+    {
+        $mockCrontab = $this->getMockBuilder('Crontab\Crontab')
+            ->setMethods(array('getCrontabFileHandler'))
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockCrontabFileHandler = $this->getMockBuilder('Crontab\CrontabFileHandler')
+            ->getMock();
+
+        $mockCrontab->expects($this->once())
+            ->method('getCrontabFileHandler')
+            ->will($this->returnValue($mockCrontabFileHandler));
+
+        $parseExistingCrontab = true;
+        $mockCrontab->__construct($parseExistingCrontab);
+    }
+
+    public function testOptionallyDoNotParseExistingCrontab()
+    {
+        $mockCrontab = $this->getMockBuilder('Crontab\Crontab')
+            ->setMethods(array('getCrontabFileHandler'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockCrontab->expects($this->never())
+            ->method('getCrontabFileHandler');
+
+        $parseExistingCrontab = false;
+        $mockCrontab->__construct($parseExistingCrontab);
+    }
 }


### PR DESCRIPTION
We use this bundle in  bamboo and would like to be able to (optionally) disable parsing pre existing crontabs.

