### PR TITLE
Parse cron variables

### DIFF
--- a/src/Crontab/Crontab.php
+++ b/src/Crontab/Crontab.php
@@ -24,6 +24,13 @@ class Crontab
     private $jobs = array();
 
     /**
+     * A collection of variables
+     *
+     * @var Variable[] $variables
+     */
+    private $variables = array();
+
+    /**
      * The user executing the comment 'crontab'
      *
      * @var string
@@ -63,7 +70,10 @@ class Crontab
      */
     public function render()
     {
-        return implode(PHP_EOL, $this->getJobs());
+        return implode(PHP_EOL, array_merge(
+            $this->getVariables(),
+            $this->getJobs()
+        ));
     }
 
     /**
@@ -152,6 +162,16 @@ class Crontab
     }
 
     /**
+     * Get all variables in crontab
+     *
+     * @return Variable[] an array of Variable
+     */
+    public function getVariables()
+    {
+        return $this->variables;
+    }
+
+    /**
      * Get crontab error
      *
      * @return string
@@ -227,6 +247,66 @@ class Crontab
     public function removeJob(Job $job)
     {
         unset($this->jobs[$job->getHash()]);
+
+        return $this;
+    }
+
+    /**
+     * @param Variable $variable
+     * @return Crontab
+     */
+    public function addVariable(Variable $variable)
+    {
+        $this->variables[$variable->getHash()] = $variable;
+
+        return $this;
+    }
+
+    /**
+     * @param Variable[] $variables
+     * @return Crontab
+     */
+    public function setVariables(array $variables)
+    {
+        foreach ($variables as $variable) {
+            $this->addVariable($variable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param Variable $variable
+     * @return Crontab
+     */
+    public function removeVariable(Variable $variable)
+    {
+        unset($this->variables[$variable->getHash()]);
+
+        return $this;
+    }
+
+    /**
+     * @return Crontab
+     */
+    public function removeAllVariables()
+    {
+        $this->variables = array();
+
+        return $this;
+    }
+
+    /**
+     * @param Job|Variable $item
+     * @return Crontab
+     */
+    public function addItem($item)
+    {
+        if ($item instanceof Job) {
+            $this->addJob($item);
+        } else if ($item instanceof Variable) {
+            $this->addVariable($item);
+        }
 
         return $this;
     }

--- a/src/Crontab/Variable.php
+++ b/src/Crontab/Variable.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @package Crontab
+ */
+
+namespace Crontab;
+
+class Variable
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        try {
+            return $this->render();
+        } catch (\Exception $exception) {
+            return '# ' . $exception;
+        }
+    }
+
+    /**
+     * Parse a variable line
+     * 
+     * @param string $varLine
+     * @return Variable
+     */
+    public static function parse($varLine)
+    {
+        $parts = explode('=', $varLine, 2);
+        if (!$parts || count($parts) !== 2) {
+            throw new \InvalidArgumentException("Line does not appear to contain a variable");
+        }
+
+        $variable = new Variable();
+        $variable->setName(trim(array_shift($parts)))
+            ->setValue(trim(array_shift($parts)));
+
+        return $variable;
+    }
+
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return $this->getName() . '=' . $this->getValue();
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param string $name
+     * @return Variable
+     * @throws \InvalidArgumentException if the variable name contain spaces or a $
+     */
+    public function setName($name)
+    {
+        if (strpos($name, ' ') !== false) {
+            throw new \InvalidArgumentException("Variable names cannot contain spaces");
+        } else if (strpos($name, '$') !== false) {
+            throw new \InvalidArgumentException("Variable names cannot contain a '\$' character");
+        }
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param string $value
+     * @return Variable
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHash()
+    {
+        return hash('md5', serialize(array(
+            strval($this->getName()),
+            strval($this->getValue())
+        )));
+    }
+}

--- a/tests/fixtures/crontab
+++ b/tests/fixtures/crontab
@@ -1,3 +1,7 @@
+MAILTO=root@localhost.localdomain
+BIN_PATH=/some/path/to/bin
+
 0 * * * * cmd
 0 * * * * cmd2
   0     *   *    *  *   indentedCommand with whitespaces
+0 * * * * $BIN_PATH/cmd3


### PR DESCRIPTION
This adds support for parsing and adding variables (such as MAILTO=email@host) in a crontab. It adds an additional Variable type with name and value attributes that can be added to, and retrieved from a Cronjob instance